### PR TITLE
Allow duplication of SFXStreamPlayer

### DIFF
--- a/addons/godot_sfxr/SfxrStreamPlayer.gd
+++ b/addons/godot_sfxr/SfxrStreamPlayer.gd
@@ -461,6 +461,12 @@ func _random_preset():
 ##################################
 
 
+func duplicate(flags: int = DUPLICATE_USE_INSTANCING | DUPLICATE_SCRIPTS):
+    var to_return = .duplicate(flags)
+    to_return.sfx_buffer = self.sfx_buffer
+    return to_return
+    
+
 func _clear_buffer():
     sfx_buffer = PoolVector2Array([])
 


### PR DESCRIPTION
This allows pre buffering the sound to play multiple times

Closes https://github.com/tomeyro/godot-sfxr/issues/3

I use this in the following way:

```gdscript
var SOUNDS = {
	"bloom": preload("sounds/Bloom.tscn")
}

func _ready():
	for key in SOUNDS:
		SOUNDS[key] = SOUNDS[key].instance()
		self.add_child(SOUNDS[key])
		SOUNDS[key]._build_buffer()
		self.remove_child(SOUNDS[key])

func _unhandled_input(event: InputEvent):
	if not event is InputEventScreenTouch: return
	if not event.pressed: return
	
	var child = SOUNDS.bloom.duplicate()
	self.add_child(child)
	child.play()
```

This allows me to pre-buffer a lot of sounds I want to play often, and then play them quickly.